### PR TITLE
Picking now works when far plane is at infinity

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -351,6 +351,12 @@ impl Gizmo {
         let mut origin = screen_to_world * Vec4::new(x, -y, -1.0, 1.0);
         origin /= origin.w;
         let mut target = screen_to_world * Vec4::new(x, -y, 1.0, 1.0);
+
+        // w is zero when far plane is set to infinity
+        if target.w.abs() < 1e-7 {
+            target.w = 1e-7;
+        }
+
         target /= target.w;
 
         let direction = target.sub(origin).xyz().normalize();


### PR DESCRIPTION
When calculating world space from screen space coordinates, a division by zero would occur if the projection had far plane set to infinity. Now a small non-zero value is used instead.

Closes #7 