### PR TITLE
Rotation gizmo works with left-handed coordinate system

### DIFF
--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
-macroquad = "0.3.16"
-egui = "0.18.1"
-egui-macroquad = "0.11.0"
+macroquad = "0.3.24"
+egui = "0.19.0"
+egui-macroquad = "0.12.0"
 egui-gizmo = { path = ".." }

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -1,7 +1,8 @@
 use std::f32::consts::FRAC_PI_4;
 
 use egui::color_picker::Alpha;
-use egui::{pos2, Align2, Color32, LayerId, Ui, Widget, FontId};
+use egui::Event::Key;
+use egui::{pos2, Align2, Color32, FontId, LayerId, Ui, Widget};
 use macroquad::prelude::*;
 
 use egui_gizmo::{
@@ -174,10 +175,12 @@ async fn main() {
                 .show(egui_ctx, |ui| {
                     ui.with_layer_id(LayerId::background(), |ui| {
                         // Snapping is enabled with ctrl key.
-                        let snapping = ui.input().modifiers.command;
+                        let snapping = is_key_down(KeyCode::LeftControl);
+                        let precise_snap = snapping && is_key_down(KeyCode::LeftShift);
+
                         // Snap angle to use for rotation when snapping is enabled.
                         // Smaller snap angle is used when shift key is pressed.
-                        let snap_angle = if ui.input().modifiers.shift {
+                        let snap_angle = if precise_snap {
                             DEFAULT_SNAP_ANGLE / 2.0
                         } else {
                             DEFAULT_SNAP_ANGLE
@@ -185,7 +188,7 @@ async fn main() {
 
                         // Snap distance to use for translation when snapping is enabled.
                         // Smaller snap distance is used when shift key is pressed.
-                        let snap_distance = if ui.input().modifiers.shift {
+                        let snap_distance = if precise_snap {
                             DEFAULT_SNAP_DISTANCE / 2.0
                         } else {
                             DEFAULT_SNAP_DISTANCE

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -1,7 +1,6 @@
 use std::f32::consts::FRAC_PI_4;
 
 use egui::color_picker::Alpha;
-use egui::Event::Key;
 use egui::{pos2, Align2, Color32, FontId, LayerId, Ui, Widget};
 use macroquad::prelude::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -472,6 +472,7 @@ pub(crate) struct GizmoConfig {
     pub scale_factor: f32,
     /// How close the mouse pointer needs to be to a subgizmo before it is focused
     pub focus_distance: f32,
+    pub left_handed: bool,
 }
 
 impl Default for GizmoConfig {
@@ -496,6 +497,7 @@ impl Default for GizmoConfig {
             mvp: Mat4::IDENTITY,
             scale_factor: 0.0,
             focus_distance: 0.0,
+            left_handed: false,
         }
     }
 }
@@ -521,6 +523,12 @@ impl GizmoConfig {
                 * 2.0;
 
         self.focus_distance = self.scale_factor * (self.visuals.stroke_width / 2.0 + 5.0);
+
+        self.left_handed = if self.projection_matrix.z_axis.w == 0.0 {
+            self.projection_matrix.z_axis.z > 0.0
+        } else {
+            self.projection_matrix.z_axis.w > 0.0
+        };
     }
 
     /// Forward vector of the view camera

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -30,7 +30,10 @@ pub(crate) fn pick_rotation(subgizmo: &SubGizmo, ui: &Ui, ray: Ray) -> Option<f3
     let angle = if subgizmo.direction == GizmoDirection::Screen {
         f32::atan2(tangent.cross(normal).dot(offset), tangent.dot(offset))
     } else {
-        let forward = config.view_forward();
+        let mut forward = config.view_forward();
+        if config.left_handed {
+            forward *= -1.0;
+        }
         f32::atan2(offset.cross(forward).dot(normal), offset.dot(forward))
     };
 
@@ -174,7 +177,10 @@ fn rotation_matrix(subgizmo: &SubGizmo) -> Mat4 {
 
         let tangent = tangent(subgizmo);
         let normal = subgizmo.normal();
-        let forward = config.view_forward();
+        let mut forward = config.view_forward();
+        if config.left_handed {
+            forward *= -1.0;
+        }
         let angle = f32::atan2(tangent.cross(forward).dot(normal), tangent.dot(forward));
 
         // Rotate towards the camera, along the rotation axis.


### PR DESCRIPTION
Fixes #14

Arcs in the rotation gizmo point in the wrong direction when using left-handed coordinate system. Now the forward vector is inverted for rotation gizmo in such case.

Also fixes snapping with ctrl & shift on Linux