### PR TITLE
Bump egui to v0.20, glam to v0.22.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ keywords = ["egui", "3d", "gizmo"]
 members = ["demo"]
 
 [dependencies]
-egui = "0.19"
-glam = "0.21"
+egui = "0.20"
+glam = "0.22"
 
 [profile.release]
 opt-level = 2

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
-macroquad = "0.3.24"
-egui = "0.19.0"
-egui-macroquad = "0.12.0"
+macroquad = "0.3.25"
+egui = "0.20.1"
+egui-macroquad = { git = "https://github.com/matthiascy/egui-macroquad.git", branch = "master" }
 egui-gizmo = { path = ".." }


### PR DESCRIPTION
While waiting for https://github.com/optozorax/egui-macroquad/pull/29#issue-1498460381 to be accepted by egui.macroquad, demo's egui-macroquad dependency has been temporarily modified to https://github.com/matthiascy/egui-macroquad.git.