### PR TITLE
Lag between gizmo and manipulated object

### DIFF
--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -226,7 +226,8 @@ async fn main() {
                             // Response contains status of the active gizmo,
                             // including an updated model matrix.
 
-                            model_matrix = Mat4::from_cols_array_2d(&gizmo_response.transform);
+                            model_matrix =
+                                Mat4::from_cols_array(gizmo_response.transform().as_ref());
 
                             show_gizmo_status(ui, gizmo_response);
                         }

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -82,7 +82,7 @@ async fn main() {
                 .resizable(false)
                 .show(egui_ctx, |ui| {
                     egui::ComboBox::from_label("Mode")
-                        .selected_text(format!("{:?}", gizmo_mode))
+                        .selected_text(format!("{gizmo_mode:?}"))
                         .show_ui(ui, |ui| {
                             ui.selectable_value(&mut gizmo_mode, GizmoMode::Rotate, "Rotate");
                             ui.selectable_value(&mut gizmo_mode, GizmoMode::Translate, "Translate");
@@ -91,7 +91,7 @@ async fn main() {
                     ui.end_row();
 
                     egui::ComboBox::from_label("Orientation")
-                        .selected_text(format!("{:?}", gizmo_orientation))
+                        .selected_text(format!("{gizmo_orientation:?}"))
                         .show_ui(ui, |ui| {
                             ui.selectable_value(
                                 &mut gizmo_orientation,

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -134,16 +134,13 @@ pub(crate) fn update_rotation(subgizmo: &SubGizmo, ui: &Ui, _ray: Ray) -> Option
         state.current_delta += angle_delta;
     });
 
-    let rotation =
+    let new_rotation =
         Quat::from_axis_angle(subgizmo.normal(), -angle_delta) * subgizmo.config.rotation;
 
     Some(GizmoResult {
-        transform: Mat4::from_scale_rotation_translation(
-            subgizmo.config.scale,
-            rotation,
-            subgizmo.config.translation,
-        )
-        .to_cols_array_2d(),
+        scale: subgizmo.config.scale,
+        rotation: new_rotation,
+        translation: subgizmo.config.translation,
         mode: GizmoMode::Rotate,
         value: (subgizmo.normal() * state.current_delta).to_array(),
     })

--- a/src/scale.rs
+++ b/src/scale.rs
@@ -83,13 +83,12 @@ pub(crate) fn update_scale(subgizmo: &SubGizmo, ui: &Ui, _ray: Ray) -> Option<Gi
 
     let offset = Vec3::ONE + (subgizmo.local_normal() * delta);
 
+    let new_scale = state.start_scale * offset;
+
     Some(GizmoResult {
-        transform: Mat4::from_scale_rotation_translation(
-            state.start_scale * offset,
-            subgizmo.config.rotation,
-            subgizmo.config.translation,
-        )
-        .to_cols_array_2d(),
+        scale: new_scale,
+        rotation: subgizmo.config.rotation,
+        translation: subgizmo.config.translation,
         mode: GizmoMode::Scale,
         value: offset.to_array(),
     })
@@ -137,13 +136,12 @@ pub(crate) fn update_scale_plane(subgizmo: &SubGizmo, ui: &Ui, _ray: Ray) -> Opt
 
     let offset = Vec3::ONE + (direction * delta);
 
+    let new_scale = state.start_scale * offset;
+
     Some(GizmoResult {
-        transform: Mat4::from_scale_rotation_translation(
-            state.start_scale * offset,
-            subgizmo.config.rotation,
-            subgizmo.config.translation,
-        )
-        .to_cols_array_2d(),
+        scale: new_scale,
+        rotation: subgizmo.config.rotation,
+        translation: subgizmo.config.translation,
         mode: GizmoMode::Scale,
         value: offset.to_array(),
     })

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -86,13 +86,12 @@ pub(crate) fn update_translation(subgizmo: &SubGizmo, ui: &Ui, ray: Ray) -> Opti
         state.current_delta = new_delta;
     });
 
+    let new_translation = subgizmo.config.translation + new_point - state.last_point;
+
     Some(GizmoResult {
-        transform: Mat4::from_scale_rotation_translation(
-            subgizmo.config.scale,
-            subgizmo.config.rotation,
-            subgizmo.config.translation + new_point - state.last_point,
-        )
-        .to_cols_array_2d(),
+        scale: subgizmo.config.scale,
+        rotation: subgizmo.config.rotation,
+        translation: new_translation,
         mode: GizmoMode::Translate,
         value: state.current_delta.to_array(),
     })
@@ -184,13 +183,12 @@ pub(crate) fn update_translation_plane(
         state.current_delta = new_delta;
     });
 
+    let new_translation = subgizmo.config.translation + new_point - state.last_point;
+
     Some(GizmoResult {
-        transform: Mat4::from_scale_rotation_translation(
-            subgizmo.config.scale,
-            subgizmo.config.rotation,
-            subgizmo.config.translation + new_point - state.last_point,
-        )
-        .to_cols_array_2d(),
+        scale: subgizmo.config.scale,
+        rotation: subgizmo.config.rotation,
+        translation: new_translation,
         mode: GizmoMode::Translate,
         value: state.current_delta.to_array(),
     })


### PR DESCRIPTION
Fixes #22

Config used for drawing the active subgizmo was not updated.
This would cause the gizmo to 'lag' behind the manipulated object,
because the gizmo drawing would use outdated information.

Now the subgizmo config is updated according to the interaction result.


Additionally:

The gizmo result now stores updated scale, rotation and translation instead of the transformation matrix.
The transformation matrix, both in Mat4 and array form, can be read with `GizmoResult::transform` and `GizmoResult::transform_cols_array_2d` respectively.