### PR TITLE
#28 Public api uses mint types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ members = ["demo"]
 
 [dependencies]
 egui = "0.23.0"
-glam = "0.24"
+glam = { version = "0.24", features = ["mint"] }
+mint = "0.5"
 
 [profile.release]
 opt-level = 2

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ let gizmo = Gizmo::new("My gizmo")
     .mode(GizmoMode::Rotate);
 
 if let Some(response) = gizmo.interact(ui) {
-    model_matrix = response.transform.into();
+    model_matrix = response.transform();
 }
 ```
 
 For a more complete example, see the [demo source code](demo/src/main.rs).
 
-The gizmo accepts matrices as `Into<[[f32; 4]; 4]>`, which means it is easy to use with matrix types from various crates
+The gizmo exposes matrices and vectors as [mint](https://github.com/kvark/mint) types, which means it is easy to use with matrix types from various crates
 such as [nalgebra](https://github.com/dimforge/nalgebra), [glam](https://github.com/bitshifter/glam-rs)
-and [cgmath](https://github.com/rustgd/cgmath).
+and [cgmath](https://github.com/rustgd/cgmath). You may need to enable a `mint` feature, depending on the math library.

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -210,9 +210,9 @@ async fn main() {
                         };
 
                         let gizmo = Gizmo::new("My gizmo")
-                            .view_matrix(view_matrix.to_cols_array_2d())
-                            .projection_matrix(projection_matrix.to_cols_array_2d())
-                            .model_matrix(model_matrix.to_cols_array_2d())
+                            .view_matrix(view_matrix.to_cols_array_2d().into())
+                            .projection_matrix(projection_matrix.to_cols_array_2d().into())
+                            .model_matrix(model_matrix.to_cols_array_2d().into())
                             .mode(gizmo_mode)
                             .orientation(gizmo_orientation)
                             .snapping(snapping)

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -138,9 +138,9 @@ pub(crate) fn update_rotation(subgizmo: &SubGizmo, ui: &Ui, _ray: Ray) -> Option
         Quat::from_axis_angle(subgizmo.normal(), -angle_delta) * subgizmo.config.rotation;
 
     Some(GizmoResult {
-        scale: subgizmo.config.scale,
-        rotation: new_rotation,
-        translation: subgizmo.config.translation,
+        scale: subgizmo.config.scale.into(),
+        rotation: new_rotation.into(),
+        translation: subgizmo.config.translation.into(),
         mode: GizmoMode::Rotate,
         value: (subgizmo.normal() * state.current_delta).to_array(),
     })

--- a/src/scale.rs
+++ b/src/scale.rs
@@ -86,9 +86,9 @@ pub(crate) fn update_scale(subgizmo: &SubGizmo, ui: &Ui, _ray: Ray) -> Option<Gi
     let new_scale = state.start_scale * offset;
 
     Some(GizmoResult {
-        scale: new_scale,
-        rotation: subgizmo.config.rotation,
-        translation: subgizmo.config.translation,
+        scale: new_scale.into(),
+        rotation: subgizmo.config.rotation.into(),
+        translation: subgizmo.config.translation.into(),
         mode: GizmoMode::Scale,
         value: offset.to_array(),
     })
@@ -139,9 +139,9 @@ pub(crate) fn update_scale_plane(subgizmo: &SubGizmo, ui: &Ui, _ray: Ray) -> Opt
     let new_scale = state.start_scale * offset;
 
     Some(GizmoResult {
-        scale: new_scale,
-        rotation: subgizmo.config.rotation,
-        translation: subgizmo.config.translation,
+        scale: new_scale.into(),
+        rotation: subgizmo.config.rotation.into(),
+        translation: subgizmo.config.translation.into(),
         mode: GizmoMode::Scale,
         value: offset.to_array(),
     })

--- a/src/subgizmo.rs
+++ b/src/subgizmo.rs
@@ -13,7 +13,7 @@ use crate::translation::{
 };
 use crate::{GizmoConfig, GizmoDirection, GizmoResult, Ray, WidgetData};
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub(crate) struct SubGizmo {
     pub(crate) id: Id,
     pub(crate) config: GizmoConfig,
@@ -127,7 +127,7 @@ impl SubGizmo {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub(crate) enum SubGizmoKind {
     /// Rotation around an axis
     RotationAxis,

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -89,9 +89,9 @@ pub(crate) fn update_translation(subgizmo: &SubGizmo, ui: &Ui, ray: Ray) -> Opti
     let new_translation = subgizmo.config.translation + new_point - state.last_point;
 
     Some(GizmoResult {
-        scale: subgizmo.config.scale,
-        rotation: subgizmo.config.rotation,
-        translation: new_translation,
+        scale: subgizmo.config.scale.into(),
+        rotation: subgizmo.config.rotation.into(),
+        translation: new_translation.into(),
         mode: GizmoMode::Translate,
         value: state.current_delta.to_array(),
     })
@@ -186,9 +186,9 @@ pub(crate) fn update_translation_plane(
     let new_translation = subgizmo.config.translation + new_point - state.last_point;
 
     Some(GizmoResult {
-        scale: subgizmo.config.scale,
-        rotation: subgizmo.config.rotation,
-        translation: new_translation,
+        scale: subgizmo.config.scale.into(),
+        rotation: subgizmo.config.rotation.into(),
+        translation: new_translation.into(),
         mode: GizmoMode::Translate,
         value: state.current_delta.to_array(),
     })


### PR DESCRIPTION
The public api is changed to use mint types instead of arrays and glam types, for consistency and clarity.