### PR TITLE
Update to egui 0.25

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui-gizmo"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Urho Laukkarinen <urho.laukkarinen@gmail.com>"]
 edition = "2021"
 
@@ -17,7 +17,7 @@ exclude = ["/docs"]
 members = ["demo"]
 
 [dependencies]
-egui = "0.24.1"
+egui = "0.25.0"
 glam = { version = "0.24", features = ["mint"] }
 mint = "0.5"
 


### PR DESCRIPTION
Just bumping the egui version and also the egui-gizmo version.
If this can be published to crates.io, that would be great.