### PR TITLE
update egui to 0.26.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui-gizmo"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["Urho Laukkarinen <urho.laukkarinen@gmail.com>"]
 edition = "2021"
 
@@ -17,7 +17,7 @@ exclude = ["/docs"]
 members = ["demo"]
 
 [dependencies]
-egui = "0.25.0"
+egui = "0.26.1"
 glam = { version = "0.25.0", features = ["mint"] }
 mint = "0.5"
 

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
-egui = "0.25"
+egui = "0.26.1"
 egui-gizmo = { path = ".." }
 
 [dependencies.bevy]
@@ -18,8 +18,8 @@ version = "0.12.1"
 features = ["mint"]
 
 [dependencies.bevy_egui]
-git = "https://github.com/urholaukkarinen/bevy_egui.git"
-rev="bc3dd1559e24ca0178ed1d2dfef07cb784437505"
+git = "https://github.com/ThomasAlban/bevy_egui.git"
+rev = "165fe4570c7b2c2c38d5f3ee49cdbe01fa5e752c"
 
 [dependencies.bevy_infinite_grid]
 git = "https://github.com/pcwalton/bevy_infinite_grid.git"


### PR DESCRIPTION
This was very simple, the only thing was that since `bevy_egui` hasn't updated to 0.26.1 yet, I switched the example to using my fork of `bevy_egui` with the update.