### PR TITLE
Fix `can't leak crate-private type` compile error

### DIFF
--- a/src/subgizmo/common.rs
+++ b/src/subgizmo/common.rs
@@ -309,7 +309,7 @@ pub(crate) fn outer_circle_radius(config: &GizmoConfig) -> f64 {
     (config.scale_factor * (config.visuals.gizmo_size + config.visuals.stroke_width + 5.0)) as f64
 }
 
-pub fn gizmo_local_normal(config: &GizmoConfig, direction: GizmoDirection) -> DVec3 {
+pub(crate) fn gizmo_local_normal(config: &GizmoConfig, direction: GizmoDirection) -> DVec3 {
     match direction {
         GizmoDirection::X => DVec3::X,
         GizmoDirection::Y => DVec3::Y,
@@ -318,7 +318,7 @@ pub fn gizmo_local_normal(config: &GizmoConfig, direction: GizmoDirection) -> DV
     }
 }
 
-pub fn gizmo_normal(config: &GizmoConfig, direction: GizmoDirection) -> DVec3 {
+pub(crate) fn gizmo_normal(config: &GizmoConfig, direction: GizmoDirection) -> DVec3 {
     let mut normal = gizmo_local_normal(config, direction);
 
     if config.local_space() && direction != GizmoDirection::View {
@@ -328,7 +328,7 @@ pub fn gizmo_normal(config: &GizmoConfig, direction: GizmoDirection) -> DVec3 {
     normal
 }
 
-pub fn gizmo_color<T: SubGizmoKind>(
+pub(crate) fn gizmo_color<T: SubGizmoKind>(
     subgizmo: &SubGizmoConfig<T>,
     direction: GizmoDirection,
 ) -> Color32 {


### PR DESCRIPTION
When used in an external package it produces the following compilation error：

```log
error[E0446]: private type `GizmoConfig` in public interface
   --> C:\Users\Varphone\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui-gizmo-0.16.0\src\subgizmo\common.rs:312:1
    |
312 | pub fn gizmo_local_normal(config: &GizmoConfig, direction: GizmoDirection) -> DVec3 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
    |
   ::: C:\Users\Varphone\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui-gizmo-0.16.0\src\lib.rs:506:1
    |
506 | pub(crate) struct GizmoConfig {
    | ----------------------------- `GizmoConfig` declared as private

error[E0446]: private type `GizmoConfig` in public interface
   --> C:\Users\Varphone\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui-gizmo-0.16.0\src\subgizmo\common.rs:321:1
    |
321 | pub fn gizmo_normal(config: &GizmoConfig, direction: GizmoDirection) -> DVec3 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
    |
   ::: C:\Users\Varphone\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui-gizmo-0.16.0\src\lib.rs:506:1
    |
506 | pub(crate) struct GizmoConfig {
    | ----------------------------- `GizmoConfig` declared as private

error[E0445]: crate-private trait `SubGizmoKind` in public interface
   --> C:\Users\Varphone\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui-gizmo-0.16.0\src\subgizmo\common.rs:331:1
    |
331 | / pub fn gizmo_color<T: SubGizmoKind>(
332 | |     subgizmo: &SubGizmoConfig<T>,
333 | |     direction: GizmoDirection,
334 | | ) -> Color32 {
    | |____________^ can't leak crate-private trait
    |
   ::: C:\Users\Varphone\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui-gizmo-0.16.0\src\subgizmo.rs:25:1
    |
25  |   pub(crate) trait SubGizmoKind: 'static {
    |   -------------------------------------- `SubGizmoKind` declared as crate-private

error[E0446]: crate-private type `SubGizmoConfig<T>` in public interface
   --> C:\Users\Varphone\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui-gizmo-0.16.0\src\subgizmo\common.rs:331:1
    |
331 | / pub fn gizmo_color<T: SubGizmoKind>(
332 | |     subgizmo: &SubGizmoConfig<T>,
333 | |     direction: GizmoDirection,
334 | | ) -> Color32 {
    | |____________^ can't leak crate-private type
    |
   ::: C:\Users\Varphone\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui-gizmo-0.16.0\src\subgizmo.rs:30:1
    |
30  |   pub(crate) struct SubGizmoConfig<T: SubGizmoKind> {
    |   ------------------------------------------------- `SubGizmoConfig<T>` declared as crate-private

Some errors have detailed explanations: E0445, E0446.
For more information about an error, try `rustc --explain E0445`.
error: could not compile `egui-gizmo` (lib) due to 4 previous errors
```
