### PR TITLE
Clip gizmo painters with viewport

### DIFF
--- a/src/painter.rs
+++ b/src/painter.rs
@@ -15,9 +15,9 @@ pub struct Painter3d {
 }
 
 impl Painter3d {
-    pub const fn new(painter: egui::Painter, mvp: DMat4, viewport: Rect) -> Self {
+    pub fn new(painter: egui::Painter, mvp: DMat4, viewport: Rect) -> Self {
         Self {
-            painter,
+            painter: painter.with_clip_rect(viewport),
             mvp,
             viewport,
         }


### PR DESCRIPTION
Allows clipping the gizmo with the viewport to prevent it from rendering over other UI. Especially usefull with things like https://github.com/rerun-io/egui_tiles